### PR TITLE
Fix access to catalog dict

### DIFF
--- a/{{cookiecutter.project_name}}/{{cookiecutter.package_name}}/__init__.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.package_name}}/__init__.py
@@ -51,11 +51,11 @@ def get_selected_streams(catalog):
     and mdata with a 'selected' entry
     '''
     selected_streams = []
-    for stream in catalog.streams:
-        stream_metadata = metadata.to_map(stream.metadata)
+    for stream in catalog["streams"]:
+        stream_metadata = metadata.to_map(stream["metadata"])
         # stream metadata will have an empty breadcrumb
         if metadata.get(stream_metadata, (), "selected"):
-            selected_streams.append(stream.tap_stream_id)
+            selected_streams.append(stream["tap_stream_id"])
 
     return selected_streams
 
@@ -64,9 +64,9 @@ def sync(config, state, catalog):
     selected_stream_ids = get_selected_streams(catalog)
 
     # Loop over streams in catalog
-    for stream in catalog.streams:
-        stream_id = stream.tap_stream_id
-        stream_schema = stream.schema
+    for stream in catalog["streams"]:
+        stream_id = stream["tap_stream_id"]
+        stream_schema = stream["schema"]
         if stream_id in selected_stream_ids:
             # TODO: sync code for stream goes here...
             LOGGER.info('Syncing stream:' + stream_id)


### PR DESCRIPTION
# Description of change
This PR fixes the dict access bug cited in the issue #6. Previously, the code broke when running in sync mode

```
python \{\{cookiecutter.package_name\}\}/__init__.py -c sample_config.json --properties catalog.json
```

with this error:
```
CRITICAL 'dict' object has no attribute 'streams'
Traceback (most recent call last):
  File "{{cookiecutter.package_name}}/__init__.py", line 95, in <module>
    main()
  File "/Users/luipillmann/opt/anaconda3/envs/singer-template/lib/python3.7/site-packages/singer/utils.py", line 229, in wrapped
    return fnc(*args, **kwargs)
  File "{{cookiecutter.package_name}}/__init__.py", line 92, in main
    sync(args.config, args.state, catalog)
  File "{{cookiecutter.package_name}}/__init__.py", line 64, in sync
    selected_stream_ids = get_selected_streams(catalog)
  File "{{cookiecutter.package_name}}/__init__.py", line 54, in get_selected_streams
    for stream in catalog.streams:
AttributeError: 'dict' object has no attribute 'streams'
```

The error was caused by wrong syntax to access dict values in Python. The code used dot notation (`my_dict.key`), whilst the right syntax is either with brackets (`my_dict["key"]`) or using the `get` method (`my_dict.get("key")`. I chose the former option, since I consider it more readable.

# Manual QA steps
Add a file `catalog.json` in  `singer-tap-template/{{cookiecutter.project_name}}` with the contents provided when running `python \{\{cookiecutter.package_name\}\}/__init__.py -c sample_config.json --discover`.

Then, run
```
python \{\{cookiecutter.package_name\}\}/__init__.py -c sample_config.json --properties catalog.json
 ```
from `singer-tap-template/{{cookiecutter.project_name}}` folder. The expected behavior is no return with no errors.

# Risks
No risks since this addresses only a few lines of code with very limited scope.
 
# Rollback steps
 - revert this branch
