### PR TITLE
Refactor to reference `Catalog.get_selected_streams()`

### DIFF
--- a/{{cookiecutter.project_name}}/{{cookiecutter.package_name}}/__init__.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.package_name}}/__init__.py
@@ -44,24 +44,9 @@ def discover():
 
     return {'streams': streams}
 
-def get_selected_streams(catalog):
-    '''
-    Gets selected streams.  Checks schema's 'selected' first (legacy)
-    and then checks metadata (current), looking for an empty breadcrumb
-    and mdata with a 'selected' entry
-    '''
-    selected_streams = []
-    for stream in catalog.streams:
-        stream_metadata = metadata.to_map(stream.metadata)
-        # stream metadata will have an empty breadcrumb
-        if metadata.get(stream_metadata, (), "selected"):
-            selected_streams.append(stream.tap_stream_id)
-
-    return selected_streams
-
 def sync(config, state, catalog):
 
-    selected_stream_ids = get_selected_streams(catalog)
+    selected_stream_ids = catalog.get_selected_streams(state)
 
     # Loop over streams in catalog
     for stream in catalog.streams:


### PR DESCRIPTION
# Description of change

- Partially resolves #8 - as related to `get_selected_streams()`

# Manual QA steps

- None yet performed.

# Risks

- Would break new users who want to replicate the template.
 
# Rollback steps

 - revert this branch
