### PR TITLE
Remove dependency pinning in template and add nota bene

### DIFF
--- a/{{cookiecutter.project_name}}/setup.py
+++ b/{{cookiecutter.project_name}}/setup.py
@@ -10,7 +10,8 @@ setup(
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["{{cookiecutter.package_name}}"],
     install_requires=[
-        "singer-python>=5.0.12",
+        # NB: Pin these to a more specific version for tap reliability
+        "singer-python",
         "requests",
     ],
     entry_points="""


### PR DESCRIPTION
# Description of change
Versions change. `singer-python` was pinned to a rather old minor version, so this removes the pin altogether and instead opts for a nota bene that says "Pin this to latest so your stuff doesn't break" :) 

# Manual QA steps
 - N/A it's a setup.py template
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
