### PR TITLE
Update __init__.py

### DIFF
--- a/{{cookiecutter.project_name}}/{{cookiecutter.package_name}}/__init__.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.package_name}}/__init__.py
@@ -63,7 +63,7 @@ def sync(config, state, catalog):
 
         singer.write_schema(
             stream_name=stream.tap_stream_id,
-            schema=stream.schema,
+            schema=stream.schema.to_dict(),
             key_properties=stream.key_properties,
         )
 


### PR DESCRIPTION
# This is actually a duplication of https://github.com/singer-io/singer-tap-template/pull/12

# Description of change
Without the addition of `to_dict()`  on l66 ( `            schema=stream.schema.to_dict(),` ) the tap will return the error 
"TypeError: Object of type 'Schema' is not JSON serializable"
Also documented by three people on Slack here: https://singer-io.slack.com/archives/C2TGFCZEV/p1584891258008800

# Manual QA steps
Rerun the schema in cookiecutter tap template. 
 
# Rollback steps
 - revert this branch
