### PR TITLE
Avoid trying to find max between None and non None value

### DIFF
--- a/{{cookiecutter.project_name}}/{{cookiecutter.package_name}}/__init__.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.package_name}}/__init__.py
@@ -82,7 +82,10 @@ def sync(config, state, catalog):
                     singer.write_state({stream.tap_stream_id: row[bookmark_column]})
                 else:
                     # if data unsorted, save max value until end of writes
-                    max_bookmark = max(max_bookmark, row[bookmark_column])
+                    if max_bookmark is None:
+                        max_bookmark = row[bookmark_column]
+                    else:
+                        max_bookmark = max(max_bookmark, row[bookmark_column])
         if bookmark_column and not is_sorted:
             singer.write_state({stream.tap_stream_id: max_bookmark})
     return


### PR DESCRIPTION
# Description of change
fixes #19 

Set the value of `max_bookmark` to the first value of the bookmark column directly without comparing the first value of the bookmark column to `None`. This avoids `TypeError` from `max(None, 1)`

# Manual QA steps
Set up a new tap project with non None bookmark column and run the tap
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
